### PR TITLE
transport: fix double free of a hash table

### DIFF
--- a/transport/owr_transport_agent.c
+++ b/transport/owr_transport_agent.c
@@ -4524,7 +4524,6 @@ void owr_transport_agent_start(OwrTransportAgent *agent)
         g_object_ref(agent);
 
         add_session(args);
-        g_hash_table_unref(args);
     }
     g_slist_free_full(agent->priv->unstarted_sessions, g_object_unref);
     agent->priv->unstarted_sessions = NULL;


### PR DESCRIPTION
`add_session` seems to take full transfer of its argument hash table